### PR TITLE
Fetch IMS registration state from one place

### DIFF
--- a/src/binder_ims_reg.h
+++ b/src/binder_ims_reg.h
@@ -17,19 +17,18 @@
 #define BINDER_IMS_REG_H
 
 #include "binder_types.h"
+#include "binder_ext_types.h"
 
 /* Object tracking IMS registration state */
 
 typedef enum binder_ims_reg_property {
     BINDER_IMS_REG_PROPERTY_ANY,
     BINDER_IMS_REG_PROPERTY_REGISTERED,
-    BINDER_IMS_REG_PROPERTY_TECH_FAMILY,
     BINDER_IMS_REG_PROPERTY_COUNT
 } BINDER_IMS_REG_PROPERTY;
 
 struct binder_ims_reg {
     gboolean registered;
-    RADIO_TECH_FAMILY tech_family;
 };
 
 typedef
@@ -42,6 +41,7 @@ void
 BinderImsReg*
 binder_ims_reg_new(
     RadioClient* client,
+    BinderExtSlot* ext_slot,
     const char* log_prefix);
 
 BinderImsReg*

--- a/src/binder_modem.c
+++ b/src/binder_modem.c
@@ -580,7 +580,7 @@ binder_modem_create(
         modem->data = binder_data_ref(data);
         modem->watch = ofono_watch_new(path);
         modem->client = radio_client_ref(client);
-        modem->ims = binder_ims_reg_new(client, log_prefix);
+        modem->ims = binder_ims_reg_new(client, ext, log_prefix);
         modem->ext = binder_ext_slot_ref(ext);
         self->g = radio_request_group_new(client);
         self->last_known_iccid = g_strdup(modem->watch->iccid);


### PR DESCRIPTION
If `BINDER_EXT_TYPE_IMS` extension is available, get IMS registration info from there.