### PR TITLE
Add support for network scan API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ SRC = \
   binder_modem.c \
   binder_netreg.c \
   binder_network.c \
+  binder_oplist.c \
   binder_radio.c \
   binder_radio_caps.c \
   binder_radio_settings.c \

--- a/binder.conf
+++ b/binder.conf
@@ -153,6 +153,17 @@
 #
 #signalStrengthRange=-100,-60
 
+# If getAvailableNetworks API is unsupported or for whatever reason
+# doesn't work, startNetworkScan can also be used to get the list of
+# available networks. Network scan API provides even more information
+# about radio technologies supported by the available operators but
+# it's only usable with IRadio interface version >= 1.2 and doesn't
+# seem to work on some devices
+#
+# Default false (try getAvailableNetworks first)
+#
+#useNetworkScan=false
+
 # With some modems, network scan returns strange operator names, i.e.
 # numeric MCC+MNC values or the same name for all operators (which is
 # actually SPN fetched from the SIM). Such strange names can be replaced

--- a/rpm/ofono-binder-plugin.spec
+++ b/rpm/ofono-binder-plugin.spec
@@ -8,8 +8,8 @@ URL: https://github.com/mer-hybris/ofono-binder-plugin
 Source: %{name}-%{version}.tar.bz2
 
 %define libglibutil_version 1.0.61
-%define libgbinder_version 1.1.15
-%define libgbinder_radio_version 1.5.0
+%define libgbinder_version 1.1.27
+%define libgbinder_radio_version 1.5.3
 %define libmce_version 1.0.6
 %define libofonobinderpluginext_version 1.1.0
 %define ofono_version 1.28+git3

--- a/src/binder_oplist.c
+++ b/src/binder_oplist.c
@@ -1,0 +1,66 @@
+/*
+ *  oFono - Open Source Telephony - binder based adaptation
+ *
+ *  Copyright (C) 2022 Jolla Ltd.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ */
+
+#include "binder_oplist.h"
+
+#include <ofono/netreg.h>
+
+BinderOpList*
+binder_oplist_new()
+{
+    return (BinderOpList*) g_array_new(FALSE, TRUE,
+        sizeof(struct ofono_network_operator));
+}
+
+BinderOpList*
+binder_oplist_set_count(
+    BinderOpList* oplist,
+    guint count)
+{
+    if (!oplist) {
+        oplist = binder_oplist_new();
+    }
+    g_array_set_size((GArray*)oplist, count);
+    return oplist;
+}
+
+BinderOpList*
+binder_oplist_append(
+    BinderOpList* oplist,
+    const struct ofono_network_operator* op)
+{
+    if (!oplist) {
+        oplist = binder_oplist_new();
+    }
+    g_array_append_vals((GArray*)oplist, op, 1);
+    return oplist;
+}
+
+void
+binder_oplist_free(
+    BinderOpList* oplist)
+{
+    if (oplist) {
+        g_array_free((GArray*)oplist, TRUE);
+    }
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/src/binder_oplist.h
+++ b/src/binder_oplist.h
@@ -1,0 +1,60 @@
+/*
+ *  oFono - Open Source Telephony - binder based adaptation
+ *
+ *  Copyright (C) 2022 Jolla Ltd.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ */
+
+#ifndef BINDER_OPLIST_H
+#define BINDER_OPLIST_H
+
+#include "binder_types.h"
+
+/*
+ * This is basically a GArray providing better type safety at compile time.
+ * If NULL is passed to binder_oplist_set_count() and binder_oplist_append()
+ * they allocate a new list with binder_oplist_new() and return it.
+ */
+typedef struct binder_oplist {
+    struct ofono_network_operator* op;
+    guint count;
+} BinderOpList;
+
+BinderOpList*
+binder_oplist_new()
+    BINDER_INTERNAL;
+
+BinderOpList*
+binder_oplist_set_count(
+    BinderOpList* oplist,
+    guint count)
+    BINDER_INTERNAL;
+
+BinderOpList*
+binder_oplist_append(
+    BinderOpList* oplist,
+    const struct ofono_network_operator* op)
+    BINDER_INTERNAL;
+
+void
+binder_oplist_free(
+    BinderOpList* oplist)
+    BINDER_INTERNAL;
+
+#endif /* BINDER_OPLIST_H */
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/src/binder_plugin.c
+++ b/src/binder_plugin.c
@@ -131,6 +131,7 @@ static const char* const binder_radio_ifaces[] = {
 #define BINDER_CONF_SLOT_DEFAULT_DATA_PROFILE_ID "defaultDataProfileId"
 #define BINDER_CONF_SLOT_MMS_DATA_PROFILE_ID  "mmsDataProfileId"
 #define BINDER_CONF_SLOT_ALLOW_DATA_REQ       "allowDataReq"
+#define BINDER_CONF_SLOT_USE_NETWORK_SCAN     "useNetworkScan"
 #define BINDER_CONF_SLOT_REPLACE_STRANGE_OPER "replaceStrangeOperatorNames"
 #define BINDER_CONF_SLOT_SIGNAL_STRENGTH_RANGE "signalStrengthRange"
 
@@ -1606,6 +1607,14 @@ binder_plugin_create_slot(
         DBG("%s: " BINDER_CONF_SLOT_ALLOW_DATA_REQ " %s", group,
             (ival == BINDER_ALLOW_DATA_ENABLED) ? "enabled": "disabled");
         slot->data_opt.allow_data = ival;
+    }
+
+    /* useNetworkScan */
+    if (ofono_conf_get_boolean(file, group,
+        BINDER_CONF_SLOT_USE_NETWORK_SCAN,
+        &config->use_network_scan)) {
+        DBG("%s: " BINDER_CONF_SLOT_USE_NETWORK_SCAN " %s", group,
+            config->use_network_scan ? "yes" : "no");
     }
 
     /* replaceStrangeOperatorNames */

--- a/src/binder_types.h
+++ b/src/binder_types.h
@@ -72,6 +72,7 @@ typedef struct binder_slot_config {
     gboolean empty_pin_query;
     gboolean radio_power_cycle;
     gboolean confirm_radio_power_on;
+    gboolean use_network_scan;
     gboolean replace_strange_oper;
     gboolean force_gsm_when_radio_off;
     BinderDataProfileConfig data_profile_config;
@@ -87,6 +88,8 @@ typedef struct binder_slot_config {
 
 typedef void (*BinderCallback)(void);
 #define BINDER_CB(f) ((BinderCallback)(f))
+
+#define OFONO_RADIO_ACCESS_MODE_COUNT (3)
 
 #define OFONO_RADIO_ACCESS_MODE_ALL (\
     OFONO_RADIO_ACCESS_MODE_GSM  |\


### PR DESCRIPTION
It's kind of a WIP because it doesn't seem to work reliably on all supported devices. But it shouldn't break anything since it's only used a fallback if `getAvailableNetworks` is not supported.