### PR TITLE
[ofono-binder-plugin] Treat no call as a remote hangup.

### DIFF
--- a/src/binder_voicecall.c
+++ b/src/binder_voicecall.c
@@ -437,7 +437,12 @@ binder_voicecall_map_cause(
 
         case RADIO_LAST_CALL_FAIL_NORMAL_UNSPECIFIED:
             call_status = binder_voicecall_status_with_id(self, cid);
-            if (call_status == OFONO_CALL_STATUS_ACTIVE ||
+            /* If call cid doesn't exist anymore, above method returns -1.
+               This case can happen, when the cause response is received
+               after the status response that removed the call from the
+               list. We then assume that the remote is the cause. */
+            if (call_status == -1 ||
+                call_status == OFONO_CALL_STATUS_ACTIVE ||
                 call_status == OFONO_CALL_STATUS_HELD ||
                 call_status == OFONO_CALL_STATUS_DIALING ||
                 call_status == OFONO_CALL_STATUS_ALERTING) {


### PR DESCRIPTION
On an incoming call, when the caller hangup
before pickup the call on device, the reason
is set as OFONO_DISCONNECT_REASON_ERROR, which
makes the device emitting three tones at full
blow.

This is due to the following exchange in the
modem:
- slot1 > 2 callStateChanged
- slot1 < [00000157] 10 getCurrentCalls
- slot1 > [00000157] 140 getCurrentCallsResponse_1_2
- slot1 < [0000015b] 19 getLastCallFailCause
- slot1 > [0000015b] 18 getLastCallFailCauseResponse

The current calls response contains no call,
so self->calls in binder_voicecall.c is emptied.
Then, the getLastCallFailCauseResponse, gives
RADIO_LAST_CALL_FAIL_NORMAL_UNSPECIFIED as a reason, so the code look for the status of the call. Which has been deleted from the list.

@monich I don't know if you would have fixed that issue like that. Don't hesitate to comment !

I'm getting this full blow tones on every remote hangup on an Xperia 10ii using 4.5.0.21, with French "Free" operator. If you want a full log, no problem to send you one, or put it here for completeness.