### PR TITLE
Only handle voice call waiting by default

### DIFF
--- a/src/binder_call_settings.c
+++ b/src/binder_call_settings.c
@@ -123,6 +123,17 @@ binder_call_settings_cw_set(
 {
     BinderCallSettings* self = binder_call_settings_get_data(s);
 
+    /*
+     * Modem seems to respond with error to all queries
+     * or settings made with bearer class
+     * BEARER_CLASS_DEFAULT. Design decision: If given
+     * class is BEARER_CLASS_DEFAULT let's map it to
+     * SERVICE_CLASS_VOICE effectively making it the
+     * default bearer.
+     */
+    if (cls == BEARER_CLASS_DEFAULT)
+        cls = BEARER_CLASS_VOICE;
+
     /* setCallWaiting(int32_t serial, bool enable, int32_t serviceClass); */
     GBinderWriter writer;
     RadioRequest* req = radio_request_new2(self->g,
@@ -207,6 +218,17 @@ void binder_call_settings_cw_query(
     void* data)
 {
     BinderCallSettings* self = binder_call_settings_get_data(s);
+
+    /*
+     * Modem seems to respond with error to all queries
+     * or settings made with bearer class
+     * BEARER_CLASS_DEFAULT. Design decision: If given
+     * class is BEARER_CLASS_DEFAULT let's map it to
+     * SERVICE_CLASS_VOICE effectively making it the
+     * default bearer.
+     */
+    if (cls == BEARER_CLASS_DEFAULT)
+        cls = BEARER_CLASS_VOICE;
 
     /* getCallWaiting(int32_t serial, int32_t serviceClass); */
     GBinderWriter writer;

--- a/src/binder_types.h
+++ b/src/binder_types.h
@@ -109,6 +109,22 @@ typedef void (*BinderCallback)(void);
 #define OFONO_RADIO_ACCESS_NR_MASK \
     (OFONO_RADIO_ACCESS_MODE_NR | (OFONO_RADIO_ACCESS_MODE_NR - 1))
 
+/* Some values copied from ofono's internal common.h */
+
+/* 27.007 Section 7.11 */
+enum bearer_class {
+        BEARER_CLASS_VOICE =            1,
+        BEARER_CLASS_DATA =             2,
+        BEARER_CLASS_FAX =              4,
+        BEARER_CLASS_DEFAULT =          7,
+        BEARER_CLASS_SMS =              8,
+        BEARER_CLASS_DATA_SYNC =        16,
+        BEARER_CLASS_DATA_ASYNC =       32,
+        BEARER_CLASS_SS_DEFAULT =       61,
+        BEARER_CLASS_PACKET =           64,
+        BEARER_CLASS_PAD =              128
+};
+
 #endif /* BINDER_TYPES_H */
 
 /*


### PR DESCRIPTION
Newer devices appear to be more strict about this parameter and getting call waiting setting fails if we ask with default value 7 (voice+data+fax). Forcing only voice call waiting fixes the issue.