### PR TITLE
[ofono-binder] Allows ignoring APN errors via config file

### DIFF
--- a/binder.conf
+++ b/binder.conf
@@ -207,3 +207,10 @@
 # Default 3 (GSM_WCDMA_AUTO)
 #
 #umtsNetworkMode=3
+
+# Ignore APN errors
+#
+# APN attachment may fail with some specific errors.
+# If you want to ignore those errors to prevent power drain, add error codes here.
+#
+# ignoreApnErrors=501

--- a/src/binder_plugin.c
+++ b/src/binder_plugin.c
@@ -137,6 +137,7 @@ static const char* const binder_radio_ifaces[] = {
 #define BINDER_CONF_SLOT_LTE_MODE             "lteNetworkMode"
 #define BINDER_CONF_SLOT_UMTS_MODE            "umtsNetworkMode"
 #define BINDER_CONF_SLOT_TECHNOLOGIES         "technologies"
+#define BINDER_CONF_SLOT_IGNORE_APN_ERRORS    "ignoreApnErrors"
 
 /* Defaults */
 #define BINDER_DEFAULT_RADIO_INTERFACE        RADIO_INTERFACE_1_2
@@ -1554,6 +1555,10 @@ binder_plugin_create_slot(
         DBG("%s: " BINDER_CONF_SLOT_DISABLE_FEATURES " 0x%04x", group, ival);
     }
 
+    /* ignoreApnErrors */
+    config->ignore_apn_errors = binder_plugin_config_get_ints(file, group,
+        BINDER_CONF_SLOT_IGNORE_APN_ERRORS);
+
     /* deviceStateTracking */
     if (ofono_conf_get_mask(file, group,
         BINDER_CONF_SLOT_DEVMON, &ival,
@@ -1726,6 +1731,7 @@ binder_plugin_slot_free(
     binder_sim_settings_unref(slot->sim_settings);
     gutil_ints_unref(slot->config.local_hangup_reasons);
     gutil_ints_unref(slot->config.remote_hangup_reasons);
+    gutil_ints_unref(slot->config.ignore_apn_errors);
     gbinder_servicemanager_remove_handler(slot->svcmgr, slot->radio_watch_id);
     gbinder_servicemanager_cancel(slot->svcmgr, slot->list_call_id);
     gbinder_servicemanager_unref(slot->svcmgr);

--- a/src/binder_types.h
+++ b/src/binder_types.h
@@ -78,6 +78,7 @@ typedef struct binder_slot_config {
     BinderDataProfileConfig data_profile_config;
     GUtilInts* local_hangup_reasons;
     GUtilInts* remote_hangup_reasons;
+    GUtilInts* ignore_apn_errors;
 } BinderSlotConfig;
 
 #define BINDER_DRIVER "binder"


### PR DESCRIPTION
Miatoll devices are failing with OEM error 503 while everything is working as expected.

This patch add an option to ignore some errors in
binder_network_set_initial_attach_apn() preventing device from flooding qcrild (and draining battery).