### PR TITLE
Always check ims caps

### DIFF
--- a/src/binder_ims.c
+++ b/src/binder_ims.c
@@ -289,6 +289,7 @@ binder_ims_probe(
             self->caps |= OFONO_IMS_VOICE_CAPABLE;
         }
     }
+    self->reg->caps = self->caps;
 
     self->start_id = g_idle_add(binder_ims_start, self);
     ofono_ims_set_data(ims, self);

--- a/src/binder_ims_reg.h
+++ b/src/binder_ims_reg.h
@@ -29,6 +29,7 @@ typedef enum binder_ims_reg_property {
 
 struct binder_ims_reg {
     gboolean registered;
+    int caps;
 };
 
 typedef

--- a/src/binder_sms.c
+++ b/src/binder_sms.c
@@ -22,6 +22,7 @@
 #include "binder_ext_slot.h"
 #include "binder_ext_sms.h"
 
+#include <ofono/ims.h>
 #include <ofono/log.h>
 #include <ofono/misc.h>
 #include <ofono/sim.h>
@@ -375,7 +376,8 @@ gboolean
 binder_sms_can_send_ims_message(
     BinderSms* self)
 {
-    return self->ims_reg && self->ims_reg->registered;
+    return self->ims_reg && self->ims_reg->registered &&
+        (self->ims_reg->caps & OFONO_IMS_SMS_CAPABLE);
 }
 
 static

--- a/src/binder_voicecall.c
+++ b/src/binder_voicecall.c
@@ -22,6 +22,7 @@
 #include "binder_ext_slot.h"
 #include "binder_ext_call.h"
 
+#include <ofono/ims.h>
 #include <ofono/log.h>
 #include <ofono/misc.h>
 #include <ofono/voicecall.h>
@@ -1030,7 +1031,8 @@ binder_voicecall_can_ext_dial(
 {
     return self->ext && (!(binder_ext_call_get_interface_flags
         (self->ext) & BINDER_EXT_CALL_INTERFACE_FLAG_IMS_REQUIRED) ||
-        (self->ims_reg && self->ims_reg->registered));
+        (self->ims_reg && self->ims_reg->registered &&
+            (self->ims_reg->caps & OFONO_IMS_VOICE_CAPABLE)));
 }
 
 static


### PR DESCRIPTION
Code assumed that both sms and voice are always supported by ims if it is registered. Always check for caps obtained from ims implementation.