### PR TITLE
Fix some memory issues in AIDL interface support

### DIFF
--- a/src/binder_network.c
+++ b/src/binder_network.c
@@ -1642,9 +1642,9 @@ binder_network_set_initial_attach_apn(
     RadioRequest* req;
     GBinderWriter writer;
 
-    if (self->interface_aidl == RADIO_AIDL_INTERFACE_NONE) {
-        binder_network_data_profile_init(&profile, ctx, RADIO_DATA_PROFILE_DEFAULT);
+    binder_network_data_profile_init(&profile, ctx, RADIO_DATA_PROFILE_DEFAULT);
 
+    if (self->interface_aidl == RADIO_AIDL_INTERFACE_NONE) {
         if (iface >= RADIO_INTERFACE_1_5) {
             /* setInitialAttachApn_1_4(int32 serial, DataProfileInfo profile); */
             req = radio_request_new2(self->g, RADIO_REQ_SET_INITIAL_ATTACH_APN_1_5,

--- a/src/binder_sms.c
+++ b/src/binder_sms.c
@@ -642,11 +642,11 @@ binder_sms_gsm_message_aidl(
      * interface expects an empty string for default SMSC.
      */
     char* tpdu;
-    tpdu = g_malloc0(sizeof(char) * (tpdu_len * 2));
     int smsc_len = pdu_len - tpdu_len;
     gint32 initial_size;
 
     /* PDU is sent as an ASCII hex string */
+    tpdu = g_malloc0(sizeof(char) * (tpdu_len * 2 + 1));
     ofono_encode_hex(pdu + smsc_len, tpdu_len, tpdu);
     DBG_(self, "%s", tpdu);
 
@@ -657,7 +657,7 @@ binder_sms_gsm_message_aidl(
     gbinder_writer_append_int32(writer, -1);
 
     gbinder_writer_append_string16_len(writer, (const char*) pdu, smsc_len);
-    gbinder_writer_append_string16_len(writer, tpdu, tpdu_len * 2);
+    gbinder_writer_append_string16_len(writer, tpdu, tpdu_len * 2 + 1);
 
     /* Overwrite parcelable size */
     gbinder_writer_overwrite_int32(writer, initial_size,


### PR DESCRIPTION
Missing initialization of data profile struct when setting initial attach APN. Incorrect size for memory of a string when sending SMS: