### PR TITLE
Makefile: honor an externally provided CC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ COVERAGE_BUILD_DIR = $(BUILD_DIR)/coverage
 # Tools and flags
 #
 
-CC = $(CROSS_COMPILE)gcc
+CC ?= $(CROSS_COMPILE)gcc
 LD = $(CC)
 STRIP ?= strip
 WARNINGS = -Wall


### PR DESCRIPTION
Hi folks! Checking in from AsteroidOS here.

Let the build system pick the compiler. The Makefile hard-codes its own CC and ignores the cross-compiler the build environment provides, so cross-compiles wrongly fall back to the host's gcc. Switching `=` to `?=` honors a compiler passed in by the environment or command line, and keeps the old default when none is given. `STRIP` in this same Makefile already uses `?=`, and the sibling libraries libgbinder and libdbusaccess use it for `CC`.

Found while cross-compiling ofono-binder-plugin with Yocto/OpenEmbedded for a 32-bit ARM AsteroidOS watch port: OpenEmbedded exports CC for the target toolchain but does not set CROSS_COMPILE, so `CC = $(CROSS_COMPILE)gcc` resolved to the host gcc.

I should add that this is a convenience more than a blocker, so do with it as you wish.